### PR TITLE
fix(ci/labeler): add issues write permission

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -7,6 +7,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: it-at-m/lhm_actions/action-templates/actions/action-pr-labeler@a7d25dbabec2057695f865169fdc411d475d4667 # v1.0.19


### PR DESCRIPTION
# Pull Request

## Changes

- CI: labeler add issues write permission for label creation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub workflow permissions to allow the pull request labeling action to write to issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->